### PR TITLE
Fixed scroll in firefox

### DIFF
--- a/src/Transition/HideShowTransition.js
+++ b/src/Transition/HideShowTransition.js
@@ -15,6 +15,7 @@ var HideShowTransition = BaseTransition.extend({
 
   finish: function() {
     document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
     this.done();
   }
 });


### PR DESCRIPTION
The scroll in firefox is binded to the documentElement instead the body.