### PR TITLE
Design fixes.

### DIFF
--- a/demo/grid/style.css
+++ b/demo/grid/style.css
@@ -26,7 +26,6 @@ a.back {
   position: absolute;
   top: 10px;
   left: 10px;
-  color: #000;
 }
 
 .barba-container {

--- a/demo/grid/style.css
+++ b/demo/grid/style.css
@@ -22,7 +22,7 @@ html, body {
 }
 
 a.back {
-  color: white;
+  color: aqua;
   position: absolute;
   top: 10px;
   left: 10px;


### PR DESCRIPTION
When I opened the first grid demo page I wasn't able to find the "Back" link and after looking very closely I saw that it's getting hidden due to the background image. 
Following are the before and after images of it. :- 
Before:
![demo_grid_1_before](https://cloud.githubusercontent.com/assets/23077544/25249771/bf370bdc-2630-11e7-85c3-4472597c2088.PNG)

After :

![demo_grid_1_after](https://cloud.githubusercontent.com/assets/23077544/25249809/e008ef56-2630-11e7-96e6-96ddeed56747.PNG)

![demo_grid_2_after](https://cloud.githubusercontent.com/assets/23077544/25249849/0f695a7e-2631-11e7-8a30-70bebc3b8024.PNG)

![demo_grid_3_after](https://cloud.githubusercontent.com/assets/23077544/25249883/2c29363e-2631-11e7-82b9-52b524189c10.PNG)

![demo_grid_4_after](https://cloud.githubusercontent.com/assets/23077544/25249898/3bee0d92-2631-11e7-86c9-7324397e181f.PNG)

And duplicate css property :

![duplicate_css_property](https://cloud.githubusercontent.com/assets/23077544/25249928/5a994482-2631-11e7-8959-13525dedf2f3.PNG)

I tried applying many existing available colors to 'go back' link to stand out from the background image and found 'aqua' working with the existing images in the demo. 

NOTE : This is my first ever contribution to open-source and I've read the guides on how to contribute and the process. If I've made any mistake then please forgive me and guide me if possible. Thanks :)   
 