### PR TITLE
Add Accept:html header

### DIFF
--- a/src/Utils/Utils.js
+++ b/src/Utils/Utils.js
@@ -67,6 +67,7 @@ var Utils = {
     req.open('GET', url);
     req.timeout = this.xhrTimeout;
     req.setRequestHeader('x-barba', 'yes');
+    req.setRequestHeader('Accept', 'text/html,application/xhtml+xml,application/xml');
     req.send();
 
     return deferred.promise;


### PR DESCRIPTION
Barba should imitate regular document requests. Here I set the `Accept` header sent by Chrome, excluding image related additions. It could probably be reduced to `text/html`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values

I noticed this because browser-sync stopped working when I added barba: https://github.com/BrowserSync/browser-sync/issues/1519