### PR TITLE
Exclude whole elements with a class

### DIFF
--- a/src/Pjax/Pjax.js
+++ b/src/Pjax/Pjax.js
@@ -274,8 +274,13 @@ var Pjax = {
     if (Utils.cleanLink(href) == Utils.cleanLink(location.href))
       return false;
 
-    if (element.classList.contains(this.ignoreClassLink))
-      return false;
+    var checking = element;
+    do {
+      if (checking.classList.contains(this.ignoreClassLink))
+        return false;
+      
+      checking = checking.parentNode;
+    } while (checking);
 
     return true;
   },

--- a/src/Pjax/Pjax.js
+++ b/src/Pjax/Pjax.js
@@ -279,7 +279,7 @@ var Pjax = {
       if (checking.classList.contains(this.ignoreClassLink))
         return false;
       
-      checking = checking.parentNode;
+      checking = checking.parentElement;
     } while (checking);
 
     return true;


### PR DESCRIPTION
Sometimes you want to exclude whole areas, like for example _WordPress' Admin bar_. 

This PR lets you just add `.no-barba` to any element and all the clicks inside it will be ignored.