### PR TITLE
[Bugfix] Force async XMLHttpRequest

### DIFF
--- a/src/Utils/Utils.js
+++ b/src/Utils/Utils.js
@@ -49,6 +49,7 @@ var Utils = {
   xhr: function(url) {
     var deferred = this.deferred();
     var req = new XMLHttpRequest();
+    var async = true;
 
     req.onreadystatechange = function() {
       if (req.readyState === 4) {
@@ -64,7 +65,7 @@ var Utils = {
       return deferred.reject(new Error('xhr: Timeout exceeded'));
     };
 
-    req.open('GET', url);
+    req.open('GET', url, async);
     req.timeout = this.xhrTimeout;
     req.setRequestHeader('x-barba', 'yes');
     req.send();


### PR DESCRIPTION
Force to make XMLHttpRequest's async because timeouts on synchronous requests fires the following error:

```
InvalidAccessError
Failed to set the 'timeout' property on 'XMLHttpRequest': Timeouts cannot be set for synchronous requests made from a document.
```

For more information see
* https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests